### PR TITLE
feat: add async event iterator utility

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,2 @@
 export * from "./src/ty.ts";
+export * from "./src/utils.ts";

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import { createTypedEvent, TypedEventEmitter } from "./ty.ts";
+import { on } from "./utils.ts";
+
+Deno.test("on yields emitted events until aborted", async () => {
+    const emitter = new TypedEventEmitter();
+    const ev = createTypedEvent<number>("count");
+    const controller = new AbortController();
+    const received: number[] = [];
+
+    const iterator = on({ ty: emitter, event: ev, signal: controller.signal });
+
+    setTimeout(() => emitter.emit(ev, 1), 0);
+    setTimeout(() => emitter.emit(ev, 2), 10);
+    setTimeout(() => controller.abort(), 20);
+
+    for await (const value of iterator) {
+        received.push(value);
+    }
+
+    assertEquals(received, [1, 2]);
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,56 @@
+import type { TypedEvent, TypedEventEmitter, TypedEventValue } from "./ty.ts";
+
+export async function* on<T extends TypedEvent<unknown>>({
+    ty,
+    event,
+    signal,
+}: {
+    ty: TypedEventEmitter;
+    event: T;
+    signal: AbortController["signal"];
+}): AsyncGenerator<TypedEventValue<T>> {
+    const queue: Array<TypedEventValue<T>> = [];
+    const resolvers: Array<
+        (
+            value: IteratorResult<TypedEventValue<T>>,
+        ) => void
+    > = [];
+
+    const listener = (payload: TypedEventValue<T>) => {
+        const resolve = resolvers.shift();
+        if (resolve) {
+            resolve({ value: payload, done: false });
+        } else {
+            queue.push(payload);
+        }
+    };
+
+    const cleanup = ty.on(event, listener);
+    const abort = () => {
+        cleanup();
+        let resolve;
+        while ((resolve = resolvers.shift())) {
+            resolve({ value: undefined as never, done: true });
+        }
+    };
+    signal.addEventListener("abort", abort, { once: true });
+
+    try {
+        while (true) {
+            if (queue.length > 0) {
+                yield queue.shift()!;
+                continue;
+            }
+            const result = await new Promise<
+                IteratorResult<TypedEventValue<T>>
+            >((resolve) => {
+                resolvers.push(resolve);
+            });
+            if (result.done) break;
+            yield result.value;
+        }
+    } finally {
+        signal.removeEventListener("abort", abort);
+        cleanup();
+    }
+}


### PR DESCRIPTION
## Summary
- add `on` async generator to yield events from TypedEventEmitter with abort support
- expose utility and add tests

## Testing
- `deno lint src/utils.ts src/utils.test.ts mod.ts`
- `deno test --allow-all` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6899c209b0e883239fc98500d5f0ed63